### PR TITLE
Use sqlite for caching package metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,6 +66,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c57d12312ff59c811c0643f4d80830505833c9ffaebd193d819392b265be8e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +102,15 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "brotli"
@@ -118,6 +147,12 @@ name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -227,6 +262,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328b822bdcba4d4e402be8d9adb6eebf269f969f8eadef977a553ff3c4fbcb58"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53757d12b596c16c78b83458d732a5d1a17ab3f53f2f7412f6fb57cc8a140ab3"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0165d2900ae6778e36e80bbc4da3b5eefccee9ba939761f9c2882a5d9af3ff"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +293,16 @@ checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
 dependencies = [
  "crossbeam-utils 0.7.2",
  "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.12",
 ]
 
 [[package]]
@@ -257,6 +326,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "dashmap"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +344,51 @@ dependencies = [
  "cfg-if 1.0.0",
  "num_cpus",
 ]
+
+[[package]]
+name = "digest"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9155c8f4dc55c7470ae9da3f63c6785245093b3f6aeb0f5bf2e968efbba314"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "encoding_rs"
@@ -289,12 +413,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "pin-project",
+ "spin",
 ]
 
 [[package]]
@@ -334,6 +476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -341,6 +484,28 @@ name = "futures-core"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62007592ac46aa7c2b6416f7deb9a8a8f63a01e0f1d6e1787d5630170db2b63e"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot 0.11.2",
+]
 
 [[package]]
 name = "futures-io"
@@ -368,11 +533,33 @@ checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -418,12 +605,27 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
+dependencies = [
+ "hashbrown 0.12.3",
+]
 
 [[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -433,6 +635,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -580,6 +788,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,6 +822,27 @@ name = "libc"
 version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -641,6 +879,12 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -685,6 +929,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sqlx",
+ "tokio",
 ]
 
 [[package]]
@@ -714,6 +960,16 @@ dependencies = [
  "rowan",
  "serde_json",
  "smol_str",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -799,10 +1055,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.3",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pin-project"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -887,6 +1217,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -1011,6 +1352,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "security-framework"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1424,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,6 +1451,12 @@ checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smol_str"
@@ -1102,6 +1475,120 @@ checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "sqlformat"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87e292b4291f154971a43c3774364e2cbcaec599d3f5bf6fa9d122885dbc38a"
+dependencies = [
+ "itertools",
+ "nom",
+ "unicode_categories",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9249290c05928352f71c077cc44a464d880c63f26f7534728cca008e135c0428"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbc16ddba161afc99e14d1713a453747a2b07fc097d2009f4c300ec99286105"
+dependencies = [
+ "ahash",
+ "atoi",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "dotenvy",
+ "either",
+ "event-listener",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "hashlink",
+ "hex",
+ "indexmap",
+ "itoa",
+ "libc",
+ "libsqlite3-sys",
+ "log",
+ "memchr",
+ "once_cell",
+ "paste",
+ "percent-encoding",
+ "sha2",
+ "smallvec",
+ "sqlformat",
+ "sqlx-rt",
+ "stringprep",
+ "thiserror",
+ "tokio-stream",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b850fa514dc11f2ee85be9d055c512aa866746adfacd1cb42d867d68e6a5b0d9"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "sha2",
+ "sqlx-core",
+ "sqlx-rt",
+ "syn",
+ "url",
+]
+
+[[package]]
+name = "sqlx-rt"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24c5b2d25fa654cc5f841750b8e1cdedbe21189bf9a9382ee90bfa9dd3562396"
+dependencies = [
+ "native-tls",
+ "once_cell",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1224,9 +1711,23 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "parking_lot 0.12.1",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1236,6 +1737,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1286,6 +1798,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,10 +1825,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "url"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,10 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
+ "lazy_static",
  "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -333,6 +336,28 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa 0.4.8",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -650,7 +675,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 1.0.4",
 ]
 
 [[package]]
@@ -700,7 +725,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.4",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -795,6 +820,12 @@ checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -921,6 +952,7 @@ name = "nix-data"
 version = "0.0.2"
 dependencies = [
  "anyhow",
+ "csv",
  "ijson",
  "lazy_static",
  "log",
@@ -1242,6 +1274,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,7 +1444,7 @@ version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
 dependencies = [
- "itoa",
+ "itoa 1.0.4",
  "ryu",
  "serde",
 ]
@@ -1418,7 +1456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 1.0.4",
  "ryu",
  "serde",
 ]
@@ -1532,7 +1570,7 @@ dependencies = [
  "hashlink",
  "hex",
  "indexmap",
- "itoa",
+ "itoa 1.0.4",
  "libc",
  "libsqlite3-sys",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ ijson = "0.1"
 nix-editor = "0.3.0-beta.1"
 log = "0.4"
 pretty_env_logger = "0.4"
+
+sqlx = { version = "0.6", features = [ "runtime-tokio-native-tls" , "sqlite" ] }
+tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ pretty_env_logger = "0.4"
 
 sqlx = { version = "0.6", features = [ "runtime-tokio-native-tls" , "sqlite" ] }
 tokio = { version = "1", features = ["full"] }
+csv = "1.1"

--- a/flake.nix
+++ b/flake.nix
@@ -19,11 +19,15 @@
         packages.nixeditor = naersk-lib.buildPackage {
           pname = "nix-data";
           root = ./.;
+          nativeBuildInputs = with pkgs; [ makeWrapper ];
           buildInputs = with pkgs; [
             openssl
             pkg-config
             sqlite
           ];
+          postInstall = ''
+            wrapProgram $out/bin/nix-data --prefix PATH : '${pkgs.lib.makeBinPath [ pkgs.sqlite ]}'
+          '';
         };
 
         defaultPackage = self.packages.${system}.nixeditor;

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
           buildInputs = with pkgs; [
             openssl
             pkg-config
+            sqlite
           ];
         };
 
@@ -37,6 +38,7 @@
             clippy
             openssl
             pkg-config
+            sqlite
           ];
         };
       });

--- a/src/cache/channel.rs
+++ b/src/cache/channel.rs
@@ -54,10 +54,10 @@ pub async fn legacypkgs() -> Result<String> {
     let client = reqwest::blocking::Client::builder().brotli(true).build()?;
     let resp = client.get(url).send()?;
     if resp.status().is_success() {
-        let db = format!("sqlite://{}/legacypkgs.db", &*CACHEDIR);
+        let dbfile = format!("{}/legacypkgs.db", &*CACHEDIR);
         let pkgjson: NixPkgList =
         serde_json::from_reader(BufReader::new(resp))?;
-        nixos::createdb(&db, &pkgjson);
+        nixos::createdb(&dbfile, &pkgjson);
     } else {
         return Err(anyhow!("Failed to download legacy packages.json"));
     }

--- a/src/cache/flakes.rs
+++ b/src/cache/flakes.rs
@@ -69,8 +69,8 @@ pub async fn flakespkgs() -> Result<String> {
         })
         .collect::<HashMap<_, _>>();
 
-    let db = format!("sqlite://{}/flakespkgs.db", &*CACHEDIR);
-    nixos::createdb(&db, &NixPkgList { packages: pkgsjson }).await?;
+    let dbfile = format!("{}/flakespkgs.db", &*CACHEDIR);
+    nixos::createdb(&dbfile, &NixPkgList { packages: pkgsjson }).await?;
 
     // Write version downloaded to file
     File::create(format!("{}/flakespkgs.ver", &*CACHEDIR))?.write_all(nixosversion.as_bytes())?;

--- a/src/cache/flakes.rs
+++ b/src/cache/flakes.rs
@@ -3,6 +3,7 @@ use anyhow::{Context, Result};
 use ijson::IString;
 use log::info;
 use serde::{Deserialize, Serialize};
+use sqlx::{migrate::MigrateDatabase, Sqlite, SqlitePool, QueryBuilder};
 use std::{
     collections::HashMap,
     fs::{self, File},
@@ -11,22 +12,18 @@ use std::{
     process::Command,
 };
 
-use super::nixos::{self, getnixospkgs};
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct FlakePkg {
-    pname: IString,
-    version: IString,
-}
+use super::{nixos::{self, getnixospkgs}, NixPkg, NixPkgList};
 
 /// Gets a list of all packages in the NixOS system with their name and version.
 /// Can be used to find what versions of system packages are currently installed.
 /// Will only work on NixOS systems.
-pub fn flakespkgs() -> Result<String> {
+pub async fn flakespkgs() -> Result<String> {
     let versionout = Command::new("nixos-version").arg("--json").output()?;
     let version: HashMap<String, String> = serde_json::from_slice(&versionout.stdout)?;
 
-    let nixosversion = version.get("nixosVersion").context("No NixOS version found")?;
+    let nixosversion = version
+        .get("nixosVersion")
+        .context("No NixOS version found")?;
 
     // If cache directory doesn't exist, create it
     if !std::path::Path::new(&*CACHEDIR).exists() {
@@ -35,9 +32,11 @@ pub fn flakespkgs() -> Result<String> {
 
     // Check if latest version is already downloaded
     if let Ok(prevver) = fs::read_to_string(&format!("{}/flakespkgs.ver", &*CACHEDIR)) {
-        if prevver.eq(nixosversion) && Path::new(&format!("{}/flakespkgs.json", &*CACHEDIR)).exists() {
+        if prevver.eq(nixosversion)
+            && Path::new(&format!("{}/flakespkgs.db", &*CACHEDIR)).exists()
+        {
             info!("No new version of NixOS flakes found");
-            return Ok(format!("{}/flakespkgs.json", &*CACHEDIR));
+            return Ok(format!("{}/flakespkgs.db", &*CACHEDIR));
         }
     }
 
@@ -58,26 +57,29 @@ pub fn flakespkgs() -> Result<String> {
             .output()?
     };
 
-    let mut pkgsjson: HashMap<IString, FlakePkg> =
+    let mut pkgsjson: HashMap<String, NixPkg> =
         serde_json::from_str(&String::from_utf8(pkgsout.stdout)?)?;
     pkgsjson = pkgsjson
         .iter()
-        .map(|(k, v)| (IString::from(k.split('.').collect::<Vec<_>>()[2..].join(".")), v.clone()))
+        .map(|(k, v)| {
+            (
+                k.split('.').collect::<Vec<_>>()[2..].join("."),
+                v.clone(),
+            )
+        })
         .collect::<HashMap<_, _>>();
-    let outjson = serde_json::to_string(&pkgsjson)?;
 
-    // Write json to cache file
-    let mut cachefile = File::create(&format!("{}/flakespkgs.json", &*CACHEDIR))?;
-    cachefile.write_all(outjson.as_bytes())?;
+    let db = format!("sqlite://{}/flakespkgs.db", &*CACHEDIR);
+    nixos::createdb(&db, &NixPkgList { packages: pkgsjson }).await?;
 
     // Write version downloaded to file
     File::create(format!("{}/flakespkgs.ver", &*CACHEDIR))?.write_all(nixosversion.as_bytes())?;
 
-    Ok(format!("{}/flakespkgs.json", &*CACHEDIR))
+    Ok(format!("{}/flakespkgs.db", &*CACHEDIR))
 }
 
 /// Returns a list of all installed system packages with their attribute and version
 /// The input `paths` should be the paths to the `configuration.nix` files containing `environment.systemPackages`
-pub fn getflakepkgs(paths: &[&str]) -> Result<HashMap<String, String>> {
-    getnixospkgs(paths, nixos::NixosType::Flake)
+pub async fn getflakepkgs(paths: &[&str]) -> Result<HashMap<String, String>> {
+    getnixospkgs(paths, nixos::NixosType::Flake).await
 }

--- a/src/cache/flakes.rs
+++ b/src/cache/flakes.rs
@@ -1,9 +1,6 @@
 use crate::CACHEDIR;
 use anyhow::{Context, Result};
-use ijson::IString;
 use log::info;
-use serde::{Deserialize, Serialize};
-use sqlx::{migrate::MigrateDatabase, Sqlite, SqlitePool, QueryBuilder};
 use std::{
     collections::HashMap,
     fs::{self, File},
@@ -12,7 +9,10 @@ use std::{
     process::Command,
 };
 
-use super::{nixos::{self, getnixospkgs}, NixPkg, NixPkgList};
+use super::{
+    nixos::{self, getnixospkgs},
+    NixPkg, NixPkgList,
+};
 
 /// Gets a list of all packages in the NixOS system with their name and version.
 /// Can be used to find what versions of system packages are currently installed.
@@ -32,8 +32,7 @@ pub async fn flakespkgs() -> Result<String> {
 
     // Check if latest version is already downloaded
     if let Ok(prevver) = fs::read_to_string(&format!("{}/flakespkgs.ver", &*CACHEDIR)) {
-        if prevver.eq(nixosversion)
-            && Path::new(&format!("{}/flakespkgs.db", &*CACHEDIR)).exists()
+        if prevver.eq(nixosversion) && Path::new(&format!("{}/flakespkgs.db", &*CACHEDIR)).exists()
         {
             info!("No new version of NixOS flakes found");
             return Ok(format!("{}/flakespkgs.db", &*CACHEDIR));
@@ -61,12 +60,7 @@ pub async fn flakespkgs() -> Result<String> {
         serde_json::from_str(&String::from_utf8(pkgsout.stdout)?)?;
     pkgsjson = pkgsjson
         .iter()
-        .map(|(k, v)| {
-            (
-                k.split('.').collect::<Vec<_>>()[2..].join("."),
-                v.clone(),
-            )
-        })
+        .map(|(k, v)| (k.split('.').collect::<Vec<_>>()[2..].join("."), v.clone()))
         .collect::<HashMap<_, _>>();
 
     let dbfile = format!("{}/flakespkgs.db", &*CACHEDIR);

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -50,7 +50,7 @@ struct Meta {
     pub maintainers: Option<Value>,
     pub position: Option<IString>,
     pub license: Option<LicenseEnum>,
-    pub platforms: Option<Platform>
+    pub platforms: Option<Platform>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -75,7 +75,7 @@ enum LicenseEnum {
     List(Vec<License>),
     SingleStr(IString),
     VecStr(Vec<IString>),
-    Mixed(Vec<LicenseEnum>)
+    Mixed(Vec<LicenseEnum>),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -93,5 +93,5 @@ struct PkgMaintainer {
     pub email: Option<IString>,
     pub github: Option<IString>,
     pub matrix: Option<IString>,
-    pub name: Option<IString>
+    pub name: Option<IString>,
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,3 +1,8 @@
+use std::collections::HashMap;
+
+use ijson::IString;
+use serde::{Deserialize, Serialize};
+
 /// Cache and determine packages installed on legacy NixOS and with `nix-env`
 pub mod channel;
 /// Cache and determine packages installed on flakes enabled NixOS
@@ -6,3 +11,20 @@ pub mod flakes;
 pub mod nixos;
 /// Cache and determine packages installed with `nix profile`
 pub mod profile;
+
+#[derive(Debug, Deserialize)]
+pub struct NixPkgList {
+    packages: HashMap<String, NixPkg>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NixPkg {
+    pname: IString,
+    version: IString,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NixosPkg {
+    pname: IString,
+    version: IString,
+}

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use ijson::IString;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// Cache and determine packages installed on legacy NixOS and with `nix-env`
 pub mod channel;
@@ -46,7 +47,7 @@ struct Meta {
     #[serde(rename = "longDescription")]
     pub longdescription: Option<IString>,
     pub homepage: Option<StrOrVec>,
-    pub maintainers: Option<ijson::IValue>,
+    pub maintainers: Option<Value>,
     pub position: Option<IString>,
     pub license: Option<LicenseEnum>,
     pub platforms: Option<Platform>

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -13,18 +13,84 @@ pub mod nixos;
 pub mod profile;
 
 #[derive(Debug, Deserialize)]
-pub struct NixPkgList {
+struct NixPkgList {
     packages: HashMap<String, NixPkg>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct NixPkg {
+struct NixPkg {
     pname: IString,
     version: IString,
 }
 
+#[derive(Debug, Deserialize)]
+struct NixosPkgList {
+    packages: HashMap<String, NixosPkg>,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct NixosPkg {
+struct NixosPkg {
     pname: IString,
     version: IString,
+    system: IString,
+    meta: Meta,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct Meta {
+    pub broken: Option<bool>,
+    pub insecure: Option<bool>,
+    pub unsupported: Option<bool>,
+    pub unfree: Option<bool>,
+    pub description: Option<IString>,
+    #[serde(rename = "longDescription")]
+    pub longdescription: Option<IString>,
+    pub homepage: Option<StrOrVec>,
+    pub maintainers: Option<ijson::IValue>,
+    pub position: Option<IString>,
+    pub license: Option<LicenseEnum>,
+    pub platforms: Option<Platform>
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(untagged)]
+enum StrOrVec {
+    Single(IString),
+    List(Vec<IString>),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum Platform {
+    Single(IString),
+    List(Vec<IString>),
+    ListList(Vec<Vec<IString>>),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(untagged)]
+enum LicenseEnum {
+    Single(License),
+    List(Vec<License>),
+    SingleStr(IString),
+    VecStr(Vec<IString>),
+    Mixed(Vec<LicenseEnum>)
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct License {
+    pub free: Option<bool>,
+    #[serde(rename = "fullName")]
+    pub fullname: Option<IString>,
+    #[serde(rename = "spdxId")]
+    pub spdxid: Option<IString>,
+    pub url: Option<IString>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct PkgMaintainer {
+    pub email: Option<IString>,
+    pub github: Option<IString>,
+    pub matrix: Option<IString>,
+    pub name: Option<IString>
 }

--- a/src/cache/nixos.rs
+++ b/src/cache/nixos.rs
@@ -106,7 +106,6 @@ pub async fn nixospkgs() -> Result<String> {
         let pkgjson: NixosPkgList =
             serde_json::from_reader(BufReader::new(resp)).expect("Failed to parse packages.json");
 
-        println!("Starting to insert packages");
         let mut wtr = csv::Writer::from_writer(vec![]);
         for (pkg, data) in &pkgjson.packages {
             wtr.serialize((

--- a/src/cache/nixos.rs
+++ b/src/cache/nixos.rs
@@ -298,7 +298,7 @@ pub(super) async fn createdb(dbfile: &str, pkgjson: &NixPkgList) -> Result<()> {
     let data = String::from_utf8(wtr.into_inner()?)?;
     let mut cmd = Command::new("sqlite3")
         .arg("-csv")
-        .arg(&format!("{}/nixospkgs.db", &*CACHEDIR))
+        .arg(&dbfile)
         .arg(".import '|cat -' pkgs")
         .stdin(Stdio::piped())
         .spawn()?;

--- a/src/cache/profile.rs
+++ b/src/cache/profile.rs
@@ -70,18 +70,6 @@ pub fn getprofilepkgs() -> Result<HashMap<String, ProfilePkg>> {
     Ok(out)
 }
 
-#[derive(Debug, Deserialize)]
-struct NixPkgListOut {
-    packages: HashMap<IString, NixPkg>
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct NixPkg {
-    name: IString,
-    pname: IString,
-    version: IString,
-}
-
 /// Returns a list of all packages installed with `nix profile` with their name and version.
 /// Takes significantly longer than [getprofilepkgs()].
 pub async fn getprofilepkgs_versioned() -> Result<HashMap<String, String>> {
@@ -95,14 +83,6 @@ pub async fn getprofilepkgs_versioned() -> Result<HashMap<String, String>> {
     let mut out = HashMap::new();
     let pool = SqlitePool::connect(&format!("sqlite://{}", latestpkgs)).await?;
     for (pkg, v) in profilepkgs {
-        let mut sqlout = sqlx::query(
-            r#"
-            .headers on
-            "#,
-        )
-        .bind(&pkg)
-        .fetch_all(&pool)
-        .await?;
         let mut sqlout = sqlx::query(
             r#"
             SELECT pname FROM pkgs WHERE attribute = $1

--- a/src/cache/profile.rs
+++ b/src/cache/profile.rs
@@ -97,6 +97,14 @@ pub async fn getprofilepkgs_versioned() -> Result<HashMap<String, String>> {
     for (pkg, v) in profilepkgs {
         let mut sqlout = sqlx::query(
             r#"
+            .headers on
+            "#,
+        )
+        .bind(&pkg)
+        .fetch_all(&pool)
+        .await?;
+        let mut sqlout = sqlx::query(
+            r#"
             SELECT pname FROM pkgs WHERE attribute = $1
             "#,
         )

--- a/src/cache/profile.rs
+++ b/src/cache/profile.rs
@@ -183,9 +183,9 @@ pub async fn nixpkgslatest() -> Result<String> {
     let client = reqwest::blocking::Client::builder().brotli(true).build()?;
     let resp = client.get(url).send()?;
     if resp.status().is_success() {
-        let db = format!("sqlite://{}/nixpkgs.db", &*CACHEDIR);
+        let dbfile = format!("{}/nixpkgs.db", &*CACHEDIR);
         let pkgjson: NixPkgList = serde_json::from_reader(BufReader::new(resp))?;
-        nixos::createdb(&db, &pkgjson).await?;
+        nixos::createdb(&dbfile, &pkgjson).await?;
     } else {
         return Err(anyhow!("Failed to download nix profile packages.json"))
     }

--- a/src/cache/profile.rs
+++ b/src/cache/profile.rs
@@ -1,7 +1,8 @@
-use crate::CACHEDIR;
+use crate::{CACHEDIR, cache::{NixPkgList, nixos}};
 use anyhow::{Context, Result, anyhow};
 use ijson::IString;
 use serde::{Deserialize, Serialize};
+use sqlx::{QueryBuilder, Sqlite, SqlitePool, migrate::MigrateDatabase, Row};
 use std::{
     collections::HashMap,
     fs::{self, File},
@@ -83,19 +84,29 @@ struct NixPkg {
 
 /// Returns a list of all packages installed with `nix profile` with their name and version.
 /// Takes significantly longer than [getprofilepkgs()].
-pub fn getprofilepkgs_versioned() -> Result<HashMap<String, String>> {
+pub async fn getprofilepkgs_versioned() -> Result<HashMap<String, String>> {
     let profilepkgs = getprofilepkgs()?;
-    let latestpkgs = if Path::new(&format!("{}/nixpkgs.json", &*CACHEDIR)).exists() {
-        format!("{}/nixpkgs.json", &*CACHEDIR)
+    let latestpkgs = if Path::new(&format!("{}/nixpkgs.db", &*CACHEDIR)).exists() {
+        format!("{}/nixpkgs.db", &*CACHEDIR)
     } else {
         // Change to something else if overridden
-        nixpkgslatest()?
+        nixpkgslatest().await?
     };
-    let pkgs: HashMap<IString, NixPkg> = serde_json::from_reader(BufReader::new(File::open(latestpkgs)?))?;
     let mut out = HashMap::new();
+    let pool = SqlitePool::connect(&format!("sqlite://{}", latestpkgs)).await?;
     for (pkg, v) in profilepkgs {
-        if let Some(nixpkg) = pkgs.get(&IString::from(pkg.to_string())) {
-            if let Some(version) = v.name.strip_prefix(&format!("{}-", nixpkg.pname.as_str())) {
+        let mut sqlout = sqlx::query(
+            r#"
+            SELECT pname FROM pkgs WHERE attribute = $1
+            "#,
+        )
+        .bind(&pkg)
+        .fetch_all(&pool)
+        .await?;
+        if sqlout.len() == 1 {
+            let row = sqlout.pop().unwrap();
+            let pname: String = row.get("pname");
+            if let Some(version) = v.name.strip_prefix(&format!("{}-", pname.as_str())) {
                 out.insert(pkg, version.to_string());
             }
         }
@@ -105,7 +116,7 @@ pub fn getprofilepkgs_versioned() -> Result<HashMap<String, String>> {
 
 /// Downloads the latest `packages.json` from nixpkgs-unstable
 /// and returns the path to the file.
-pub fn nixpkgslatest() -> Result<String> {
+pub async fn nixpkgslatest() -> Result<String> {
     // If cache directory doesn't exist, create it
     if !std::path::Path::new(&*CACHEDIR).exists() {
         std::fs::create_dir_all(&*CACHEDIR)?;
@@ -146,10 +157,10 @@ pub fn nixpkgslatest() -> Result<String> {
     info!("latestnixpkgsver: {}", latestnixpkgsver);
     // Check if latest version is already downloaded
     if let Ok(prevver) = fs::read_to_string(&format!("{}/nixpkgs.ver", &*CACHEDIR)) {
-        if prevver == latestnixpkgsver && Path::new(&format!("{}/nixpkgs.json", &*CACHEDIR)).exists()
+        if prevver == latestnixpkgsver && Path::new(&format!("{}/nixpkgs.db", &*CACHEDIR)).exists()
         {
             debug!("No new version of nixpkgs found");
-            return Ok(format!("{}/nixpkgs.json", &*CACHEDIR));
+            return Ok(format!("{}/nixpkgs.db", &*CACHEDIR));
         }
     }
 
@@ -164,16 +175,12 @@ pub fn nixpkgslatest() -> Result<String> {
     let client = reqwest::blocking::Client::builder().brotli(true).build()?;
     let resp = client.get(url).send()?;
     if resp.status().is_success() {
-        let mut out = File::create(&format!("{}/nixpkgs.json", &*CACHEDIR))?;
-        let output: NixPkgListOut = serde_json::from_slice(&resp.bytes()?)?;
-        let outjson = serde_json::to_string(&output.packages)?;
-        out.write_all(outjson.as_bytes())?;
-        // Write version downloaded to file
-        File::create(format!("{}/nixpkgs.ver", &*CACHEDIR))?
-            .write_all(latestnixpkgsver.as_bytes())?;
+        let db = format!("sqlite://{}/nixpkgs.db", &*CACHEDIR);
+        let pkgjson: NixPkgList = serde_json::from_reader(BufReader::new(resp))?;
+        nixos::createdb(&db, &pkgjson).await?;
     } else {
         return Err(anyhow!("Failed to download nix profile packages.json"))
     }
 
-    Ok(format!("{}/nixpkgs.json", &*CACHEDIR))
+    Ok(format!("{}/nixpkgs.db", &*CACHEDIR))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,8 @@ pub mod cache;
 pub mod config;
 
 lazy_static::lazy_static! {
-    static ref CACHEDIR: String = format!("{}/.cache/nix-data/", std::env::var("HOME").unwrap());
-    static ref CONFIGDIR: String = format!("{}/.config/nix-data/", std::env::var("HOME").unwrap());
-    static ref CONFIG: String = format!("{}config.json", &*CONFIGDIR);
+    static ref CACHEDIR: String = format!("{}/.cache/nix-data", std::env::var("HOME").unwrap());
+    static ref CONFIGDIR: String = format!("{}/.config/nix-data", std::env::var("HOME").unwrap());
+    static ref CONFIG: String = format!("{}/config.json", &*CONFIGDIR);
 }
 static SYSCONFIG: &str = "/etc/nix-data/config.json";

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,5 +2,5 @@ use nix_data::cache;
 
 #[tokio::main]
 async fn main() {
-    println!("{:?}", cache::profile::getprofilepkgs_versioned().await);
+    println!("{:?}", cache::nixos::nixospkgs().await);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,5 +2,5 @@ use nix_data::cache;
 
 #[tokio::main]
 async fn main() {
-    println!("{:?}", cache::nixos::nixospkgs().await);
+    println!("{:?}", cache::profile::getprofilepkgs_versioned().await);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,6 @@
+use nix_data::cache;
+
+#[tokio::main]
+async fn main() {
+    println!("{:?}", cache::profile::getprofilepkgs_versioned().await);
+}


### PR DESCRIPTION
Using a database system like SQLite provides a faster way of querying data related to packages, while also reducing the memory cost needed as before the entire JSON file was loaded into memory for ever derivative program.