### PR TITLE
Do not access systemconfig if not set

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -34,7 +34,7 @@ in
     };
   };
 
-  config = mkIf (cfg.enable || cfg.systemconfig != null || cfg.flake != null || cfg.flakearg != null || cfg.generations != null) {
+  config = mkIf cfg.enable {
       environment.etc."nix-data/config.json".source = jsonFormat.generate "config.json" { inherit (cfg) systemconfig flake flakearg generations; };
     };
 }


### PR DESCRIPTION
This fixes:
error: The option `programs.nix-data.systemconfig' is used but not defined.